### PR TITLE
Added data type support to tx input and event subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ POST http://localhost:3000/transactions?fly-sync=true&fly-signer=user001&fly-cha
             }, {
                 "name": "color", "type": "string"
             }, {
-                "name": "size", "type": "string"
+                "name": "size", "type": "integer"
             }, {
                 "name": "owner", "type": "string"
             }, {
@@ -115,7 +115,7 @@ POST http://localhost:3000/transactions?fly-sync=true&fly-signer=user001&fly-cha
     "args": {
         "owner": "Tom",
         "value": "123000",
-        "size": "10",
+        "size": 10,
         "id": "asset203",
         "color": "red"
     }
@@ -154,7 +154,7 @@ POST http://localhost:3000/transactions?fly-sync=true&fly-signer=user001&fly-cha
             }, {
                 "name": "color", "type": "string"
             }, {
-                "name": "size", "type": "string"
+                "name": "size", "type": "integer"
             }, {
                 "name": "owner", "type": "string"
             }, {
@@ -177,7 +177,7 @@ POST http://localhost:3000/transactions?fly-sync=true&fly-signer=user001&fly-cha
             "appraisedValue": 123000,
             "inspected": true
         },
-        "size": "10",
+        "size": 10,
         "id": "asset205",
         "color": "red"
     }

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954
 	github.com/urfave/cli v1.22.2 // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
+	github.com/xeipuuv/gojsonschema v1.2.0
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489 // indirect
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect

--- a/go.sum
+++ b/go.sum
@@ -653,6 +653,12 @@ github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJ
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xdg/scram v1.0.3/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.3/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -225,7 +225,7 @@ type RestErrMsg struct {
 }
 
 func RestErrReply(res http.ResponseWriter, req *http.Request, err error, status int) {
-	log.Errorf("<-- %s %s [%d]: %s", req.Method, req.URL, status, err)
+	log.Errorf("<-- %s %s [%d]: \n%s", req.Method, req.URL, status, err)
 	reply, _ := json.Marshal(&RestErrMsg{Message: err.Error()})
 	res.Header().Set("Content-Type", "application/json")
 	res.WriteHeader(status)

--- a/internal/events/api/event.go
+++ b/internal/events/api/event.go
@@ -17,8 +17,11 @@
 package api
 
 const (
-	BlockType_TX     = "tx"     // corresponds to blocks containing regular transactions
-	BlockType_Config = "config" // corresponds to blocks containing channel configurations and updates
+	BlockType_TX                     = "tx"              // corresponds to blocks containing regular transactions
+	BlockType_Config                 = "config"          // corresponds to blocks containing channel configurations and updates
+	EventPayloadType_Bytes           = "bytes"           // default data type of the event payload, no special processing is done before returning to the subscribing client
+	EventPayloadType_String          = "string"          // event payload will be an UTF-8 encoded string
+	EventPayloadType_StringifiedJSON = "stringifiedJSON" // event payload will be a structured map with UTF-8 encoded string values
 )
 
 // persistedFilter is the part of the filter we record to storage
@@ -40,15 +43,16 @@ type persistedFilter struct {
 // SubscriptionInfo is the persisted data for the subscription
 type SubscriptionInfo struct {
 	TimeSorted
-	ID        string          `json:"id,omitempty"`
-	ChannelId string          `json:"channel,omitempty"`
-	Path      string          `json:"path"`
-	Summary   string          `json:"-"`      // System generated name for the subscription
-	Name      string          `json:"name"`   // User provided name for the subscription, set to Summary if missing
-	Stream    string          `json:"stream"` // the event stream this subscription is associated under
-	Signer    string          `json:"signer"`
-	FromBlock string          `json:"fromBlock,omitempty"`
-	Filter    persistedFilter `json:"filter"`
+	ID          string          `json:"id,omitempty"`
+	ChannelId   string          `json:"channel,omitempty"`
+	Path        string          `json:"path"`
+	Summary     string          `json:"-"`      // System generated name for the subscription
+	Name        string          `json:"name"`   // User provided name for the subscription, set to Summary if missing
+	Stream      string          `json:"stream"` // the event stream this subscription is associated under
+	Signer      string          `json:"signer"`
+	FromBlock   string          `json:"fromBlock,omitempty"`
+	Filter      persistedFilter `json:"filter"`
+	PayloadType string          `json:"payloadType,omitempty"` // optinal. data type of the payload bytes; "bytes", "string" or "stringifiedJSON". Default to "bytes"
 }
 
 // GetID returns the ID (for sorting)
@@ -57,11 +61,11 @@ func (info *SubscriptionInfo) GetID() string {
 }
 
 type EventEntry struct {
-	ChaincodeId   string `json:"chaincodeId"`
-	BlockNumber   uint64 `json:"blockNumber"`
-	TransactionId string `json:"transactionId"`
-	EventName     string `json:"eventName"`
-	Payload       []byte `json:"payload"`
-	Timestamp     uint64 `json:"timestamp,omitempty"`
-	SubID         string `json:"subId"`
+	ChaincodeId   string      `json:"chaincodeId"`
+	BlockNumber   uint64      `json:"blockNumber"`
+	TransactionId string      `json:"transactionId"`
+	EventName     string      `json:"eventName"`
+	Payload       interface{} `json:"payload"`
+	Timestamp     uint64      `json:"timestamp,omitempty"`
+	SubID         string      `json:"subId"`
 }

--- a/internal/events/api/event.go
+++ b/internal/events/api/event.go
@@ -52,7 +52,7 @@ type SubscriptionInfo struct {
 	Signer      string          `json:"signer"`
 	FromBlock   string          `json:"fromBlock,omitempty"`
 	Filter      persistedFilter `json:"filter"`
-	PayloadType string          `json:"payloadType,omitempty"` // optinal. data type of the payload bytes; "bytes", "string" or "stringifiedJSON". Default to "bytes"
+	PayloadType string          `json:"payloadType,omitempty"` // optional. data type of the payload bytes; "bytes", "string" or "stringifiedJSON". Default to "bytes"
 }
 
 // GetID returns the ID (for sorting)

--- a/internal/events/eventstream.go
+++ b/internal/events/eventstream.go
@@ -87,11 +87,15 @@ type webSocketActionInfo struct {
 	DistributionMode DistributionMode `json:"distributionMode,omitempty"`
 }
 
+// defined to allow mocking in tests
+type eventHandler func(*eventData)
+
 type eventStream struct {
 	sm                subscriptionManager
 	allowPrivateIPs   bool
 	spec              *StreamInfo
 	eventStream       chan *eventData
+	eventHandler      eventHandler
 	stopped           bool
 	processorDone     bool
 	pollingInterval   time.Duration
@@ -158,6 +162,7 @@ func newEventStream(sm subscriptionManager, spec *StreamInfo, wsChannels ws.WebS
 		pollingInterval:   time.Duration(sm.getConfig().PollingIntervalSec) * time.Second,
 		wsChannels:        wsChannels,
 	}
+	a.eventHandler = a.handleEvent
 
 	if a.pollingInterval == 0 {
 		// Let's us do this from UTs, without exposing it

--- a/internal/events/evtprocessor_test.go
+++ b/internal/events/evtprocessor_test.go
@@ -1,0 +1,65 @@
+// Copyright 2021 Kaleido
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+
+	"github.com/hyperledger/firefly-fabconnect/internal/events/api"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventPayloadUnmarshaling(t *testing.T) {
+	assert := assert.New(t)
+	_, stream, svr, eventStream := newTestStreamForBatching(
+		&StreamInfo{
+			Name:    "testStream",
+			Webhook: &webhookActionInfo{},
+		}, nil, 200)
+	defer close(eventStream)
+	defer svr.Close()
+	defer stream.stop()
+
+	p := newEvtProcessor("abc", stream)
+	subInfo := &api.SubscriptionInfo{
+		ID:          "abc",
+		PayloadType: api.EventPayloadType_StringifiedJSON,
+	}
+	jsonstring := "{\"ID\":\"asset1072\",\"color\":\"yellow\",\"size\":10,\"owner\":\"Tom\",\"appraisedValue\":1300}"
+	entry := &api.EventEntry{
+		Payload: []byte(jsonstring),
+	}
+	err := p.processEventEntry(subInfo, entry)
+	assert.NoError(err)
+	decoded := entry.Payload.(map[string]interface{})
+	assert.Equal("asset1072", decoded["ID"])
+
+	subInfo.PayloadType = api.EventPayloadType_String
+	entry.Payload = []byte(jsonstring)
+	err = p.processEventEntry(subInfo, entry)
+	assert.NoError(err)
+	_, ok := entry.Payload.(string)
+	assert.True(ok)
+	assert.Equal(jsonstring, entry.Payload)
+
+	subInfo.PayloadType = ""
+	entry.Payload = []byte(jsonstring)
+	err = p.processEventEntry(subInfo, entry)
+	assert.NoError(err)
+	_, ok = entry.Payload.([]byte)
+	assert.True(ok)
+	assert.Equal([]byte(jsonstring), entry.Payload)
+}

--- a/internal/events/subscription.go
+++ b/internal/events/subscription.go
@@ -124,7 +124,7 @@ func (s *subscription) processNewEvents() {
 			}
 			events := fabric.GetEvents(blockEvent.Block)
 			for _, event := range events {
-				if err := s.ep.processEventEntry(s.info.ID, event); err != nil {
+				if err := s.ep.processEventEntry(s.info, event); err != nil {
 					log.Errorf("Failed to process event: %s", err)
 				}
 			}
@@ -140,7 +140,7 @@ func (s *subscription) processNewEvents() {
 				EventName:     ccEvent.EventName,
 				Payload:       ccEvent.Payload,
 			}
-			if err := s.ep.processEventEntry(s.info.ID, event); err != nil {
+			if err := s.ep.processEventEntry(s.info, event); err != nil {
 				log.Errorf("Failed to process event: %s", err)
 			}
 		}

--- a/internal/events/subscription_test.go
+++ b/internal/events/subscription_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Kaleido
+// Copyright 2021 Kaleido
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -52,6 +52,7 @@ type CommonHeaders struct {
 	Signer        string                 `json:"signer,omitempty"`
 	ChannelID     string                 `json:"channel,omitempty"`
 	ChaincodeName string                 `json:"chaincode,omitempty"`
+	PayloadSchema interface{}            `json:"payloadSchema,omitempty"` // can be stringified JSON or map for JSON
 	Context       map[string]interface{} `json:"ctx,omitempty"`
 }
 

--- a/internal/rest/router.go
+++ b/internal/rest/router.go
@@ -124,6 +124,7 @@ func (r *router) sendTransaction(res http.ResponseWriter, req *http.Request, par
 	msg, opts, err := restutil.BuildTxMessage(res, req, params)
 	if err != nil {
 		errors.RestErrReply(res, req, err.Error, err.StatusCode)
+		return
 	}
 	if opts.Sync {
 		r.syncDispatcher.DispatchMsgSync(req.Context(), res, req, msg)

--- a/internal/rest/utils/params.go
+++ b/internal/rest/utils/params.go
@@ -17,6 +17,8 @@
 package util
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -24,6 +26,7 @@ import (
 	"github.com/hyperledger/firefly-fabconnect/internal/messages"
 	"github.com/hyperledger/firefly-fabconnect/internal/utils"
 	"github.com/julienschmidt/httprouter"
+	jsonschema "github.com/xeipuuv/gojsonschema"
 )
 
 type TxOpts struct {
@@ -121,15 +124,11 @@ func BuildTxMessage(res http.ResponseWriter, req *http.Request, params httproute
 	if msg.Function == "" {
 		return nil, nil, NewRestError("Must specify target chaincode function", 400)
 	}
-	argsVal := body["args"]
-	if argsVal == nil {
-		return nil, nil, NewRestError("Must specify args", 400)
+	argsVal, err := processArgs(body)
+	if err != nil {
+		return nil, nil, NewRestError(err.Error(), 400)
 	}
-	args := make([]string, len(argsVal.([]interface{})))
-	for i, v := range argsVal.([]interface{}) {
-		args[i] = v.(string)
-	}
-	msg.Args = args
+	msg.Args = argsVal
 
 	opts := TxOpts{}
 	opts.Sync = true
@@ -152,4 +151,116 @@ func BuildTxMessage(res http.ResponseWriter, req *http.Request, params httproute
 	}
 
 	return &msg, &opts, nil
+}
+
+func processArgs(body map[string]interface{}) ([]string, error) {
+	var args []string
+	argsVal := body["args"]
+	if argsVal == nil {
+		return nil, fmt.Errorf("must specify args")
+	}
+
+	var payloadSchema interface{}
+	headers := body["headers"]
+	if headers != nil {
+		payloadSchema = headers.(map[string]interface{})["payloadSchema"]
+	}
+	if payloadSchema != nil {
+		// if a payload schema is provided, the args property in the body must be a JSON structure
+		argsMap, ok := argsVal.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("the \"args\" property must be JSON if a payload schema is provided")
+		}
+
+		// the payload JSON schema can be supplied as a stringified JSON or expanded JSON
+		var schemaloader jsonschema.JSONLoader
+		schemaStr, ok := payloadSchema.(string)
+		if ok {
+			schemaloader = jsonschema.NewStringLoader(schemaStr)
+		} else {
+			schemaMap, ok := payloadSchema.(map[string]interface{})
+			if ok {
+				schemaloader = jsonschema.NewGoLoader(schemaMap)
+			} else {
+				return nil, fmt.Errorf("invalid payload schema")
+			}
+		}
+
+		// the schema must specify an array root property
+		schema, err := schemaloader.LoadJSON()
+		if err != nil {
+			return nil, err
+		}
+		schemaMap := schema.(map[string]interface{})
+		rootType := schemaMap["type"]
+		if rootType.(string) != "array" {
+			return nil, fmt.Errorf("payload schema must define a root type of \"array\"")
+		}
+		// we require the schema to use "prefixItems" to define the ordered array of arguments
+		pitems := schemaMap["prefixItems"]
+		if pitems == nil {
+			return nil, fmt.Errorf("payload schema must define a root type of \"array\" using \"prefixItems\"")
+		}
+
+		// only one level of property definitions are needed in order to understand
+		// how to validate the args and marshal them into the array of strings to pass into Fabric
+		items := pitems.([]interface{})
+		args = make([]string, len(items))
+		for i, item := range items {
+			itemDef := item.(map[string]interface{})
+			name := itemDef["name"]
+			if name == nil {
+				return nil, fmt.Errorf("property definitions of the \"prefixItems\" in the payload schema must have a \"name\"")
+			}
+			entry := argsMap[name.(string)]
+
+			// validate the args entry against the schema, matching by "name"
+			err := validate(itemDef, name.(string), entry)
+			if err != nil {
+				return nil, err
+			}
+
+			propType := itemDef["type"].(string)
+			if propType == "object" {
+				encoded, _ := json.Marshal(entry)
+				args[i] = string(encoded)
+			} else {
+				strVal, ok := entry.(string)
+				if !ok {
+					return nil, fmt.Errorf("top level argument properties in the payload schema must be string values or objects")
+				}
+				args[i] = strVal
+			}
+		}
+	} else {
+		// no payload schema provided, treat the args as array of strings
+		argVals, ok := argsVal.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("no payload schema is specified in the payload's \"headers\", the \"args\" property must be an array of strings")
+		}
+		args = make([]string, len(argVals))
+		for i, v := range argsVal.([]interface{}) {
+			args[i] = v.(string)
+		}
+	}
+
+	return args, nil
+}
+
+func validate(def map[string]interface{}, name string, value interface{}) error {
+	// let's use the schema to validate the body args payload first
+	document := jsonschema.NewGoLoader(value)
+	schemaloader := jsonschema.NewGoLoader(def)
+	result, err := jsonschema.Validate(schemaloader, document)
+	if err != nil {
+		return fmt.Errorf("failed to validate argument \"%s\": %s", name, err)
+	}
+	if !result.Valid() {
+		errorMsg := ""
+		for _, desc := range result.Errors() {
+			errorMsg = fmt.Sprintf("%s- %s\n", errorMsg, desc)
+		}
+		return fmt.Errorf("failed to validate argument \"%s\": %s", name, errorMsg)
+	}
+	return nil
 }

--- a/internal/rest/utils/params_test.go
+++ b/internal/rest/utils/params_test.go
@@ -1,0 +1,310 @@
+// Copyright 2021 Kaleido
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var payloadNoSchema = `{
+	"headers": {
+			"type": "SendTransaction"
+	},
+	"func": "CreateAsset",
+	"args": ["asset204", "red", "10", "Tom", "123000"]
+}`
+
+var payloadSimpleSchema = `{
+	"headers": {
+			"type": "SendTransaction",
+			"payloadSchema": {
+					"type": "array",
+					"prefixItems": [{
+							"name": "id", "type": "string"
+					}, {
+							"name": "color", "type": "string"
+					}, {
+							"name": "size", "type": "string"
+					}, {
+							"name": "owner", "type": "string"
+					}, {
+							"name": "value", "type": "string"
+					}]
+			}
+	},
+	"func": "CreateAsset",
+	"args": {
+			"owner": "Tom",
+			"value": "123000",
+			"size": "10",
+			"id": "asset204",
+			"color": "red"
+	}
+}`
+
+var payloadComplexSchema = `{
+	"headers": {
+			"type": "SendTransaction",
+			"payloadSchema": {
+					"type": "array",
+					"prefixItems": [{
+							"name": "id", "type": "string"
+					}, {
+							"name": "color", "type": "string"
+					}, {
+							"name": "size", "type": "string"
+					}, {
+							"name": "owner", "type": "string"
+					}, {
+							"name": "appraisal", "type": "object",
+							"properties": {
+									"appraisedValue": {
+											"type": "integer"
+									},
+									"inspected": {
+											"type": "boolean"
+									}
+							}
+					}]
+			}
+	},
+	"func": "CreateAsset",
+	"args": {
+			"owner": "Tom",
+			"appraisal": {
+					"appraisedValue": 123000,
+					"inspected": true
+			},
+			"size": "10",
+			"id": "asset204",
+			"color": "red"
+	}
+}`
+
+var payloadNoArgs = `{
+	"headers": {
+			"type": "SendTransaction"
+	},
+	"func": "CreateAsset"
+}`
+
+var payloadArgsNotJSON = `{
+	"headers": {
+			"type": "SendTransaction",
+			"payloadSchema": {
+					"type": "array",
+					"prefixItems": [{
+							"name": "id", "type": "string"
+					}, {
+							"name": "color", "type": "string"
+					}, {
+							"name": "size", "type": "string"
+					}, {
+							"name": "owner", "type": "string"
+					}, {
+							"name": "value", "type": "string"
+					}]
+			}
+	},
+	"func": "CreateAsset",
+	"args": ["asset204", "red", "10", "Tom", "123000"]
+}`
+
+var payloadArgsBadSchema1 = `{
+	"headers": {
+			"type": "SendTransaction",
+			"payloadSchema": ["bad schema"]
+	},
+	"func": "CreateAsset",
+	"args": {}
+}`
+
+var payloadArgsBadSchema2 = `{
+	"headers": {
+			"type": "SendTransaction",
+			"payloadSchema": {
+				"type": "object"
+			}
+	},
+	"func": "CreateAsset",
+	"args": {}
+}`
+
+var payloadArgsNotPrefixItems = `{
+	"headers": {
+			"type": "SendTransaction",
+			"payloadSchema": {
+					"type": "array",
+					"items": [{
+							"name": "id", "type": "string"
+					}, {
+							"name": "color", "type": "string"
+					}, {
+							"name": "size", "type": "string"
+					}, {
+							"name": "owner", "type": "string"
+					}, {
+							"name": "value", "type": "string"
+					}]
+			}
+	},
+	"func": "CreateAsset",
+	"args": {}
+}`
+
+var payloadArgsItemsWithNoName = `{
+	"headers": {
+			"type": "SendTransaction",
+			"payloadSchema": {
+					"type": "array",
+					"prefixItems": [{
+							"type": "string"
+					}]
+			}
+	},
+	"func": "CreateAsset",
+	"args": {}
+}`
+
+var payloadObjectNoSchema = `{
+	"headers": {
+			"type": "SendTransaction"
+	},
+	"func": "CreateAsset",
+	"args": {}
+}`
+
+var payloadSimpleSchemaBadValue = `{
+	"headers": {
+			"type": "SendTransaction",
+			"payloadSchema": {
+					"type": "array",
+					"prefixItems": [{
+							"name": "id", "type": "string"
+					}]
+			}
+	},
+	"func": "CreateAsset",
+	"args": {
+			"id": 100
+	}
+}`
+
+func TestProcessArgsNotSchema(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadNoSchema), &body)
+
+	args, err := processArgs(body)
+	assert.NoError(err)
+	assert.Equal(args, []string{"asset204", "red", "10", "Tom", "123000"})
+}
+
+func TestProcessArgsSimpleSchema(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadSimpleSchema), &body)
+
+	args, err := processArgs(body)
+	assert.NoError(err)
+	assert.Equal(args, []string{"asset204", "red", "10", "Tom", "123000"})
+}
+
+func TestProcessArgsComplexSchema(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadComplexSchema), &body)
+
+	args, err := processArgs(body)
+	assert.NoError(err)
+	assert.Equal(args, []string{"asset204", "red", "10", "Tom", "{\"appraisedValue\":123000,\"inspected\":true}"})
+}
+
+func TestProcessArgsMissingArgs(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadNoArgs), &body)
+
+	_, err := processArgs(body)
+	assert.EqualError(err, "must specify args")
+}
+
+func TestProcessArgsNotJSON(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadArgsNotJSON), &body)
+
+	_, err := processArgs(body)
+	assert.EqualError(err, "the \"args\" property must be JSON if a payload schema is provided")
+}
+
+func TestProcessArgsBadSchema(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadArgsBadSchema1), &body)
+
+	_, err := processArgs(body)
+	assert.EqualError(err, "invalid payload schema")
+}
+
+func TestProcessArgsWrongRootType(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadArgsBadSchema2), &body)
+
+	_, err := processArgs(body)
+	assert.EqualError(err, "payload schema must define a root type of \"array\"")
+}
+
+func TestProcessArgsNotPrefixItems(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadArgsNotPrefixItems), &body)
+
+	_, err := processArgs(body)
+	assert.EqualError(err, "payload schema must define a root type of \"array\" using \"prefixItems\"")
+}
+
+func TestProcessArgsItemsHaveNoName(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadArgsItemsWithNoName), &body)
+
+	_, err := processArgs(body)
+	assert.EqualError(err, "property definitions of the \"prefixItems\" in the payload schema must have a \"name\"")
+}
+
+func TestProcessArgsObjectWithNoSchema(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadObjectNoSchema), &body)
+
+	_, err := processArgs(body)
+	assert.EqualError(err, "no payload schema is specified in the payload's \"headers\", the \"args\" property must be an array of strings")
+}
+
+func TestProcessArgsBadValue(t *testing.T) {
+	assert := assert.New(t)
+	body := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(payloadSimpleSchemaBadValue), &body)
+
+	_, err := processArgs(body)
+	assert.EqualError(err, "failed to validate argument \"id\": - (root): Invalid type. Expected: string, given: integer\n")
+}


### PR DESCRIPTION
## Transaction Input
payload schema can be specified in the `headers` section of the request body. Complex types are supported for chaincodes that takes structs as input:
```
{
    "headers": {
        "type": "SendTransaction",
        "payloadSchema": {
            "type": "array",
            "prefixItems": [{
                "name": "id", "type": "string"
            }, {
                "name": "color", "type": "string"
            }, {
                "name": "size", "type": "string"
            }, {
                "name": "owner", "type": "string"
            }, {
                "name": "appraisal", "type": "object",
                "properties": {
                    "appraisedValue": {
                        "type": "integer"
                    },
                    "inspected": {
                        "type": "boolean"
                    }
                }
            }]
        }
    },
    "func": "CreateAsset",
    "args": {
        "owner": "Tom",
        "appraisal": {
            "appraisedValue": 123000,
            "inspected": true
        },
        "size": "10",
        "id": "asset205",
        "color": "red"
    }
}
```
## Event Payload
Previously, the event payload is always send to the listening client as the byte array originally obtained from Fabric's event object:

```
{
    "chaincodeId": "asset_transfer",
    "blockNumber": 126,
    "transactionId": "ff1c69f8e891a6aa43378ecd2a914f4a0ea3f3cfb23247ecc298a2e66a5c5970",
    "eventName": "AssetCreated",
    "payload": "eyJJRCI6ImFzc2V0MTA2OSIsImNvbG9yIjoieWVsbG93Iiwic2l6ZSI6MTAsIm93bmVyIjoiVG9tIiwiYXBwcmFpc2VkVmFsdWUiOjEzMDB9",
    "subId": "sb-6366481d-1495-4a89-6e57-b9403d781208"
  }
```

With the enhancement, a `payloadType` property can be specified during event subscription, that can provide one of 3 types to instruct the event processor in fabconnect to unmarshal the byte array before sending to the client:
- `string`: the byte array will be encoded as UTF-8 strings,
```
{
    "chaincodeId": "asset_transfer",
    "blockNumber": 131,
    "transactionId": "c38dc609f86298e2ef407cc645aeec134fb08cbe283565501bb8b38103fcaee0",
    "eventName": "AssetCreated",
    "payload": "{\"ID\":\"asset1074\",\"color\":\"yellow\",\"size\":10,\"owner\":\"Tom\",\"appraisedValue\":1300}",
    "subId": "sb-ad7adeb7-5f40-4157-51b9-5caa35a1fd4d"
  }
```
- `stringifiedJSON`: the byte array will be encoded as fully expanded string maps,
```
{
    "chaincodeId": "asset_transfer",
    "blockNumber": 130,
    "transactionId": "83be13b68874253655eefde7cb992b4b53bea7b919eed742f91a08b802aadd98",
    "eventName": "AssetCreated",
    "payload": {
      "ID": "asset1073",
      "appraisedValue": 1300,
      "color": "yellow",
      "owner": "Tom",
      "size": 10
    },
    "subId": "sb-bb06eaaf-cc71-422b-581a-b3ded393d63d"
  }
```
- `bytes`: which is the default, the byte array is left alone without any further treatment
