### PR TITLE
Add spec.yaml to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN make build
 
 FROM alpine:latest
 WORKDIR /fabconnect
-COPY --from=fabconnect-builder /fabconnect/fabconnect ./fabconnect
+COPY --from=fabconnect-builder /fabconnect/fabconnect \
+  /fabconnect/openapi/ \
+  ./
 RUN ln -s /fabconnect/fabconnect /usr/bin/fabconnect
 ENTRYPOINT [ "fabconnect" ]


### PR DESCRIPTION
Missed this when adding the API spec capability. The static resource must be added to the runtime image for it to be available to serve to present the Swagger UI