### PR TITLE
Fill in event fields from transactions that do not publish events

### DIFF
--- a/internal/fabric/utils/blockdecoder.go
+++ b/internal/fabric/utils/blockdecoder.go
@@ -38,16 +38,20 @@ func GetEvents(block *common.Block) []*api.EventEntry {
 	}
 	for idx, entry := range rawBlock.Data.Data {
 		timestamp := entry.Payload.Header.ChannelHeader.Timestamp
+		txId := entry.Payload.Header.ChannelHeader.TxId
 		actions := entry.Payload.Data.Actions
 		for actionIdx, action := range actions {
 			event := action.Payload.Action.ProposalResponsePayload.Extension.Events
 			if event == nil {
 				continue
 			}
+			// if the transaction did not publish any events, we need to get most of the
+			// information below from other parts of the transaction
+			chaincodeId := action.Payload.Action.ProposalResponsePayload.Extension.ChaincodeId.Name
 			eventEntry := api.EventEntry{
-				ChaincodeId:      event.ChaincodeId,
+				ChaincodeId:      chaincodeId,
 				BlockNumber:      rawBlock.Header.Number,
-				TransactionId:    event.TxId,
+				TransactionId:    txId,
 				TransactionIndex: idx,
 				EventIndex:       actionIdx, // each action only allowed one event, so event index is the action index
 				EventName:        event.EventName,


### PR DESCRIPTION
If a transaction does not publish an event, the event object published by the event stream has mostly empty fields:

```
{
    "chaincodeId": "",
    "blockNumber": 12,
    "transactionId": "",
    "transactionIndex": 0,
    "eventIndex": 0,
    "eventName": "",
    "payload": "",
    "timestamp": 1645073064291071927,
    "subId": "sb-f2d3ed2e-2f34-4b79-7763-87755a3f8391"
  }
```

The fields `chaincodeId` and `transactionId` should be filled in from the transaction object that contained the event.

After the fix, the fields are filled in:

```
{
    "chaincodeId": "_lifecycle",
    "blockNumber": 12,
    "transactionId": "052935d3e4debb3e67b40249153ec006f2d419b058df7f604b9b3311796b8934",
    "transactionIndex": 0,
    "eventIndex": 0,
    "eventName": "",
    "payload": "",
    "timestamp": 1645073064291071927,
    "subId": "sb-f2d3ed2e-2f34-4b79-7763-87755a3f8391"
  }
```