### PR TITLE
Configurable Chaincode Query targets

### DIFF
--- a/internal/fabric/client/api.go
+++ b/internal/fabric/client/api.go
@@ -53,7 +53,7 @@ type RegistrationWrapper struct {
 
 type RPCClient interface {
 	Invoke(channelId, signer, chaincodeName, method string, args []string, isInit bool) (*TxReceipt, error)
-	Query(channelId, signer, chaincodeName, method string, args []string) ([]byte, error)
+	Query(channelId, signer, chaincodeName, method string, args []string, strongread bool) ([]byte, error)
 	QueryChainInfo(channelId, signer string) (*fab.BlockchainInfoResponse, error)
 	QueryBlock(channelId string, blockNumber uint64, signer string) (*utils.RawBlock, *utils.Block, error)
 	QueryTransaction(channelId, signer, txId string) (map[string]interface{}, error)

--- a/internal/fabric/client/client_ccp.go
+++ b/internal/fabric/client/client_ccp.go
@@ -28,8 +28,6 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	mspImpl "github.com/hyperledger/fabric-sdk-go/pkg/msp"
 	"github.com/hyperledger/firefly-fabconnect/internal/errors"
-	eventsapi "github.com/hyperledger/firefly-fabconnect/internal/events/api"
-	"github.com/hyperledger/firefly-fabconnect/internal/fabric/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -42,15 +40,9 @@ type ccpClientWrapper struct {
 }
 
 type ccpRPCWrapper struct {
-	txTimeout           int
-	configProvider      core.ConfigProvider
-	sdk                 *fabsdk.FabricSDK
-	cryptoSuiteConfig   core.CryptoSuiteConfig
-	userStore           msp.UserStore
-	idClient            IdentityClient
-	ledgerClientWrapper *ledgerClientWrapper
-	eventClientWrapper  *eventClientWrapper
-	channelCreator      channelCreator
+	*commonRPCWrapper
+	cryptoSuiteConfig core.CryptoSuiteConfig
+	userStore         msp.UserStore
 	// one channel client per channel ID, per signer ID
 	channelClients map[string](map[string]*ccpClientWrapper)
 }
@@ -69,16 +61,18 @@ func newRPCClientFromCCP(configProvider core.ConfigProvider, txTimeout int, user
 
 	log.Infof("New gRPC connection established")
 	w := &ccpRPCWrapper{
-		sdk:                 ledgerClientWrapper.sdk,
-		configProvider:      configProvider,
-		cryptoSuiteConfig:   cryptoConfig,
-		userStore:           userStore,
-		idClient:            idClient,
-		ledgerClientWrapper: ledgerClientWrapper,
-		eventClientWrapper:  eventClientWrapper,
-		channelClients:      make(map[string]map[string]*ccpClientWrapper),
-		channelCreator:      createChannelClient,
-		txTimeout:           txTimeout,
+		commonRPCWrapper: &commonRPCWrapper{
+			sdk:                 ledgerClientWrapper.sdk,
+			configProvider:      configProvider,
+			idClient:            idClient,
+			ledgerClientWrapper: ledgerClientWrapper,
+			eventClientWrapper:  eventClientWrapper,
+			channelCreator:      createChannelClient,
+			txTimeout:           txTimeout,
+		},
+		cryptoSuiteConfig: cryptoConfig,
+		userStore:         userStore,
+		channelClients:    make(map[string]map[string]*ccpClientWrapper),
 	}
 	return w, nil
 }
@@ -126,59 +120,6 @@ func (w *ccpRPCWrapper) Query(channelId, signer, chaincodeName, method string, a
 
 	log.Tracef("RPC [%s:%s:%s] <-- %+v", channelId, chaincodeName, method, result)
 	return result.Payload, nil
-}
-
-func (w *ccpRPCWrapper) QueryTransaction(channelId, signer, txId string) (map[string]interface{}, error) {
-	log.Tracef("RPC [%s] --> QueryTransaction %s", channelId, txId)
-
-	result, err := w.ledgerClientWrapper.queryTransaction(channelId, signer, txId)
-	if err != nil {
-		log.Errorf("Failed to query transaction on channel %s. %s", channelId, err)
-		return nil, err
-	}
-
-	log.Tracef("RPC [%s] <-- %+v", channelId, result)
-	return result, nil
-}
-
-func (w *ccpRPCWrapper) QueryChainInfo(channelId, signer string) (*fab.BlockchainInfoResponse, error) {
-	log.Tracef("RPC [%s] --> ChainInfo", channelId)
-
-	result, err := w.ledgerClientWrapper.queryChainInfo(channelId, signer)
-	if err != nil {
-		log.Errorf("Failed to query chain info on channel %s. %s", channelId, err)
-		return nil, err
-	}
-
-	log.Tracef("RPC [%s] <-- %+v", channelId, result)
-	return result, nil
-}
-
-func (w *ccpRPCWrapper) QueryBlock(channelId string, blockNumber uint64, signer string) (*utils.RawBlock, *utils.Block, error) {
-	log.Tracef("RPC [%s] --> QueryBlock %v", channelId, blockNumber)
-
-	rawblock, block, err := w.ledgerClientWrapper.queryBlock(channelId, blockNumber, signer)
-	if err != nil {
-		log.Errorf("Failed to query block %v on channel %s. %s", blockNumber, channelId, err)
-		return nil, nil, err
-	}
-
-	log.Tracef("RPC [%s] <-- success", channelId)
-	return rawblock, block, nil
-}
-
-// The returned registration must be closed when done
-func (w *ccpRPCWrapper) SubscribeEvent(subInfo *eventsapi.SubscriptionInfo, since uint64) (*RegistrationWrapper, <-chan *fab.BlockEvent, <-chan *fab.CCEvent, error) {
-	reg, blockEventCh, ccEventCh, err := w.eventClientWrapper.subscribeEvent(subInfo, since)
-	if err != nil {
-		log.Errorf("Failed to subscribe to event [%s:%s:%s]. %s", subInfo.Stream, subInfo.ChannelId, subInfo.Filter.ChaincodeId, err)
-		return nil, nil, nil, err
-	}
-	return reg, blockEventCh, ccEventCh, nil
-}
-
-func (w *ccpRPCWrapper) Unregister(regWrapper *RegistrationWrapper) {
-	regWrapper.eventClient.Unregister(regWrapper.registration)
 }
 
 func (w *ccpRPCWrapper) getChannelClient(channelId string, signer string) (*ccpClientWrapper, error) {
@@ -247,23 +188,4 @@ func (w *ccpRPCWrapper) sendTransaction(channelId, signer, chaincodeName, method
 		return nil, nil, nil, err
 	}
 	return client.signer, result.Payload, &txStatus, nil
-}
-
-func convert(args []string) [][]byte {
-	result := [][]byte{}
-	for _, v := range args {
-		result = append(result, []byte(v))
-	}
-	return result
-}
-
-func newReceipt(responsePayload []byte, status *fab.TxStatusEvent, signerID *msp.IdentityIdentifier) *TxReceipt {
-	return &TxReceipt{
-		SignerMSP:     signerID.MSPID,
-		Signer:        signerID.ID,
-		TransactionID: status.TxID,
-		Status:        status.TxValidationCode,
-		BlockNumber:   status.BlockNumber,
-		SourcePeer:    status.SourceURL,
-	}
 }

--- a/internal/fabric/client/client_common.go
+++ b/internal/fabric/client/client_common.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/context"
+	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/core"
+	"github.com/hyperledger/firefly-fabconnect/internal/errors"
+)
+
+func getOrgFromConfig(config core.ConfigProvider) (string, error) {
+	configBackend, err := config()
+	if err != nil {
+		return "", err
+	}
+	if len(configBackend) != 1 {
+		return "", errors.Errorf("Invalid config file")
+	}
+
+	cfg := configBackend[0]
+	value, ok := cfg.Lookup("client.organization")
+	if !ok {
+		return "", errors.Errorf("No client organization defined in the config")
+	}
+
+	return value.(string), nil
+}
+
+func getFirstPeerEndpointFromConfig(config core.ConfigProvider) (string, error) {
+	org, err := getOrgFromConfig(config)
+	if err != nil {
+		return "", err
+	}
+	configBackend, _ := config()
+	cfg := configBackend[0]
+	value, ok := cfg.Lookup(fmt.Sprintf("organizations.%s.peers", org))
+	if !ok {
+		return "", errors.Errorf("No peers list found in the organization %s", org)
+	}
+	peers := value.([]interface{})
+	if len(peers) < 1 {
+		return "", errors.Errorf("Peers list for organization %s is empty", org)
+	}
+	return peers[0].(string), nil
+}
+
+// defined to allow mocking in tests
+type channelCreator func(context.ChannelProvider) (*channel.Client, error)
+
+func createChannelClient(channelProvider context.ChannelProvider) (*channel.Client, error) {
+	return channel.New(channelProvider)
+}

--- a/internal/fabric/client/client_gateway_clientside.go
+++ b/internal/fabric/client/client_gateway_clientside.go
@@ -27,8 +27,6 @@ import (
 	"github.com/hyperledger/fabric-sdk-go/pkg/fabsdk"
 	"github.com/hyperledger/fabric-sdk-go/pkg/gateway"
 	"github.com/hyperledger/firefly-fabconnect/internal/errors"
-	eventsapi "github.com/hyperledger/firefly-fabconnect/internal/events/api"
-	"github.com/hyperledger/firefly-fabconnect/internal/fabric/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -37,14 +35,9 @@ type gatewayCreator func(core.ConfigProvider, string, int) (*gateway.Gateway, er
 type networkCreator func(*gateway.Gateway, string) (*gateway.Network, error)
 
 type gwRPCWrapper struct {
-	txTimeout           int
-	configProvider      core.ConfigProvider
-	idClient            IdentityClient
-	ledgerClientWrapper *ledgerClientWrapper
-	eventClientWrapper  *eventClientWrapper
-	gatewayCreator      gatewayCreator
-	networkCreator      networkCreator
-	channelCreator      channelCreator
+	*commonRPCWrapper
+	gatewayCreator gatewayCreator
+	networkCreator networkCreator
 	// networkCreator networkC
 	// one gateway client per signer
 	gwClients map[string]*gateway.Gateway
@@ -56,17 +49,19 @@ type gwRPCWrapper struct {
 
 func newRPCClientWithClientSideGateway(configProvider core.ConfigProvider, txTimeout int, idClient IdentityClient, ledgerClientWrapper *ledgerClientWrapper, eventClientWrapper *eventClientWrapper) (RPCClient, error) {
 	return &gwRPCWrapper{
-		txTimeout:           txTimeout,
-		configProvider:      configProvider,
-		idClient:            idClient,
-		ledgerClientWrapper: ledgerClientWrapper,
-		eventClientWrapper:  eventClientWrapper,
-		gatewayCreator:      createGateway,
-		networkCreator:      getNetwork,
-		channelCreator:      createChannelClient,
-		gwClients:           make(map[string]*gateway.Gateway),
-		gwGatewayClients:    make(map[string]map[string]*gateway.Network),
-		gwChannelClients:    make(map[string]map[string]*channel.Client),
+		commonRPCWrapper: &commonRPCWrapper{
+			txTimeout:           txTimeout,
+			configProvider:      configProvider,
+			idClient:            idClient,
+			ledgerClientWrapper: ledgerClientWrapper,
+			eventClientWrapper:  eventClientWrapper,
+			channelCreator:      createChannelClient,
+		},
+		gatewayCreator:   createGateway,
+		networkCreator:   getNetwork,
+		gwClients:        make(map[string]*gateway.Gateway),
+		gwGatewayClients: make(map[string]map[string]*gateway.Network),
+		gwChannelClients: make(map[string]map[string]*channel.Client),
 	}, nil
 }
 
@@ -100,10 +95,7 @@ func (w *gwRPCWrapper) Query(channelId, signer, chaincodeName, method string, ar
 		return nil, err
 	}
 
-	bytes := make([][]byte, len(args))
-	for i, v := range args {
-		bytes[i] = []byte(v)
-	}
+	bytes := convert(args)
 	req := channel.Request{
 		ChaincodeID: chaincodeName,
 		Fcn:         method,
@@ -117,59 +109,6 @@ func (w *gwRPCWrapper) Query(channelId, signer, chaincodeName, method string, ar
 
 	log.Tracef("RPC [%s:%s:%s] <-- %+v", channelId, chaincodeName, method, result)
 	return result.Payload, nil
-}
-
-func (w *gwRPCWrapper) QueryChainInfo(channelId, signer string) (*fab.BlockchainInfoResponse, error) {
-	log.Tracef("RPC [%s] --> ChainInfo", channelId)
-
-	result, err := w.ledgerClientWrapper.queryChainInfo(channelId, signer)
-	if err != nil {
-		log.Errorf("Failed to query chain info on channel %s. %s", channelId, err)
-		return nil, err
-	}
-
-	log.Tracef("RPC [%s] <-- %+v", channelId, result)
-	return result, nil
-}
-
-func (w *gwRPCWrapper) QueryBlock(channelId string, blockNumber uint64, signer string) (*utils.RawBlock, *utils.Block, error) {
-	log.Tracef("RPC [%s] --> QueryBlock %v", channelId, blockNumber)
-
-	rawblock, block, err := w.ledgerClientWrapper.queryBlock(channelId, blockNumber, signer)
-	if err != nil {
-		log.Errorf("Failed to query block %v on channel %s. %s", blockNumber, channelId, err)
-		return nil, nil, err
-	}
-
-	log.Tracef("RPC [%s] <-- success", channelId)
-	return rawblock, block, nil
-}
-
-func (w *gwRPCWrapper) QueryTransaction(channelId, signer, txId string) (map[string]interface{}, error) {
-	log.Tracef("RPC [%s] --> QueryTransaction %s", channelId, txId)
-
-	result, err := w.ledgerClientWrapper.queryTransaction(channelId, signer, txId)
-	if err != nil {
-		log.Errorf("Failed to query transaction on channel %s. %s", channelId, err)
-		return nil, err
-	}
-
-	log.Tracef("RPC [%s] <-- %+v", channelId, result)
-	return result, nil
-}
-
-// The returned registration must be closed when done
-func (w *gwRPCWrapper) SubscribeEvent(subInfo *eventsapi.SubscriptionInfo, since uint64) (*RegistrationWrapper, <-chan *fab.BlockEvent, <-chan *fab.CCEvent, error) {
-	reg, blockEventCh, ccEventCh, err := w.eventClientWrapper.subscribeEvent(subInfo, since)
-	if err != nil {
-		log.Errorf("Failed to subscribe to event [%s:%s:%s]. %s", subInfo.Stream, subInfo.ChannelId, subInfo.Filter.ChaincodeId, err)
-		return nil, nil, nil, err
-	}
-	return reg, blockEventCh, ccEventCh, nil
-}
-
-func (w *gwRPCWrapper) Unregister(regWrapper *RegistrationWrapper) {
-	regWrapper.eventClient.Unregister(regWrapper.registration)
 }
 
 func (w *gwRPCWrapper) Close() error {

--- a/internal/fabric/client/rpc_test.go
+++ b/internal/fabric/client/rpc_test.go
@@ -182,13 +182,40 @@ func TestGatewayClientInstantiation(t *testing.T) {
 
 	wrapper.gatewayCreator = createMockGateway
 	wrapper.networkCreator = createMockNetwork
-	client, err := wrapper.getChannelClient("default-channel", "user1")
+	client, err := wrapper.getGatewayClient("default-channel", "user1")
 	assert.NoError(err)
 	assert.NotNil(client)
 	assert.Equal(1, len(wrapper.gwClients))
+	assert.Equal(0, len(wrapper.gwChannelClients))
 
 	gw := wrapper.gwClients["user1"]
 	assert.NotNil(gw)
+	assert.Equal(1, len(wrapper.gwGatewayClients))
+	assert.Equal(1, len(wrapper.gwGatewayClients["user1"]))
+	assert.Equal(client, wrapper.gwGatewayClients["user1"]["default-channel"])
+}
+
+func TestChannelClientInstantiation(t *testing.T) {
+	assert := assert.New(t)
+
+	config := conf.RPCConf{
+		UseGatewayClient: true,
+		ConfigPath:       tmpShortCCPFile,
+	}
+	rpc, idclient, err := RPCConnect(config, 5)
+	assert.NoError(err)
+	assert.NotNil(rpc)
+	assert.NotNil(idclient)
+
+	wrapper, ok := rpc.(*gwRPCWrapper)
+	assert.True(ok)
+
+	wrapper.channelCreator = createMockChannelClient
+	client, err := wrapper.getChannelClient("default-channel", "user1")
+	assert.NoError(err)
+	assert.NotNil(client)
+	assert.Equal(0, len(wrapper.gwClients))
+	assert.Equal(0, len(wrapper.gwGatewayClients))
 	assert.Equal(1, len(wrapper.gwChannelClients))
 	assert.Equal(1, len(wrapper.gwChannelClients["user1"]))
 	assert.Equal(client, wrapper.gwChannelClients["user1"]["default-channel"])

--- a/internal/fabric/test/helper.go
+++ b/internal/fabric/test/helper.go
@@ -52,7 +52,7 @@ func MockRPCClient(fromBlock string, withReset ...bool) *mockfabric.RPCClient {
 	chaincodeResult := []byte(`{"AppraisedValue":123000,"Color":"red","ID":"asset01","Owner":"Tom","Size":10}`)
 	txResult["transaction"] = tx1
 	rpc.On("SubscribeEvent", mock.Anything, mock.Anything).Return(nil, roBlockEventChan, roCCEventChan, nil)
-	rpc.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(chaincodeResult, nil)
+	rpc.On("Query", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(chaincodeResult, nil)
 	rpc.On("QueryChainInfo", mock.Anything, mock.Anything).Return(res, nil)
 	rpc.On("QueryBlock", mock.Anything, mock.Anything, mock.Anything).Return(rawBlock, block, nil)
 	rpc.On("QueryTransaction", mock.Anything, mock.Anything, mock.Anything).Return(txResult, nil)

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -94,8 +94,9 @@ func (r *ReplyCommon) ReplyHeaders() *ReplyHeaders {
 // QueryChaincode message instructs the bridge to install a contract
 type QueryChaincode struct {
 	RequestCommon
-	Function string   `json:"func"`
-	Args     []string `json:"args,omitempty"`
+	Function   string   `json:"func"`
+	Args       []string `json:"args,omitempty"`
+	StrongRead bool     `json:"strongread"`
 }
 
 type GetTxById struct {

--- a/internal/rest/sync/syncdispatcher.go
+++ b/internal/rest/sync/syncdispatcher.go
@@ -188,7 +188,7 @@ func (d *syncDispatcher) QueryChaincode(res http.ResponseWriter, req *http.Reque
 		return
 	}
 
-	result, err1 := d.processor.GetRPCClient().Query(msg.Headers.ChannelID, msg.Headers.Signer, msg.Headers.ChaincodeName, msg.Function, msg.Args)
+	result, err1 := d.processor.GetRPCClient().Query(msg.Headers.ChannelID, msg.Headers.Signer, msg.Headers.ChaincodeName, msg.Function, msg.Args, msg.StrongRead)
 	callTime := time.Now().UTC().Sub(start)
 	if err1 != nil {
 		log.Warnf("Query [chaincode=%s, func=%s] failed to send: %s [%.2fs]", msg.Headers.ChaincodeName, msg.Function, err1, callTime.Seconds())

--- a/internal/rest/utils/params.go
+++ b/internal/rest/utils/params.go
@@ -118,6 +118,19 @@ func BuildQueryMessage(res http.ResponseWriter, req *http.Request, params httpro
 		return nil, NewRestError(err.Error(), 400)
 	}
 	msg.Args = argsVal
+	strongread := body["strongread"]
+	if strongread != nil {
+		strVal, ok := strongread.(string)
+		if ok {
+			isStrongread, err := strconv.ParseBool(strVal)
+			if err != nil {
+				return nil, NewRestError(err.Error(), 400)
+			}
+			msg.StrongRead = isStrongread
+		} else {
+			msg.StrongRead = strongread.(bool)
+		}
+	}
 
 	return &msg, nil
 }

--- a/mocks/fabric/client/rpc_client.go
+++ b/mocks/fabric/client/rpc_client.go
@@ -55,13 +55,13 @@ func (_m *RPCClient) Invoke(channelId string, signer string, chaincodeName strin
 	return r0, r1
 }
 
-// Query provides a mock function with given fields: channelId, signer, chaincodeName, method, args
-func (_m *RPCClient) Query(channelId string, signer string, chaincodeName string, method string, args []string) ([]byte, error) {
-	ret := _m.Called(channelId, signer, chaincodeName, method, args)
+// Query provides a mock function with given fields: channelId, signer, chaincodeName, method, args, strongread
+func (_m *RPCClient) Query(channelId string, signer string, chaincodeName string, method string, args []string, strongread bool) ([]byte, error) {
+	ret := _m.Called(channelId, signer, chaincodeName, method, args, strongread)
 
 	var r0 []byte
-	if rf, ok := ret.Get(0).(func(string, string, string, string, []string) []byte); ok {
-		r0 = rf(channelId, signer, chaincodeName, method, args)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, []string, bool) []byte); ok {
+		r0 = rf(channelId, signer, chaincodeName, method, args, strongread)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
@@ -69,8 +69,8 @@ func (_m *RPCClient) Query(channelId string, signer string, chaincodeName string
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, string, []string) error); ok {
-		r1 = rf(channelId, signer, chaincodeName, method, args)
+	if rf, ok := ret.Get(1).(func(string, string, string, string, []string, bool) error); ok {
+		r1 = rf(channelId, signer, chaincodeName, method, args, strongread)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
This allows a chaincode query against the `POST /query` endpoint to choose to target a single peer (the first peer in the peers list for the client organization), or use the selection service to assemble a set of peers and compare endorsement results.

Default is targeting a single peer.

Add `strongread: true` to the payload to use the selection service.