### PR TITLE
Use existing transient map support in the gateway client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,5 +51,3 @@ require (
 )
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.0
-
-replace github.com/hyperledger/fabric-sdk-go => github.com/kaleido-io/fabric-sdk-go v1.0.1-0.20221104172459-a5cbbfd0c1d6

--- a/go.sum
+++ b/go.sum
@@ -386,6 +386,8 @@ github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDW
 github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/hyperledger/fabric-protos-go v0.0.0-20211118165945-23d738fc3553 h1:E9f0v1q4EDfrE+0LdkxVtdYKAZ7PGCaj1bBx45R9yEQ=
 github.com/hyperledger/fabric-protos-go v0.0.0-20211118165945-23d738fc3553/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
+github.com/hyperledger/fabric-sdk-go v1.0.1-0.20220617091732-e170b98fa821 h1:0VfkWCv8MPDjm+6xoD6t3yN075AQ2x2KTcLY1m5BJno=
+github.com/hyperledger/fabric-sdk-go v1.0.1-0.20220617091732-e170b98fa821/go.mod h1:JRplpKBeAvXjsBhOCCM/KvMRUbdDyhsAh80qbXzKc10=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -429,8 +431,6 @@ github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSg
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
-github.com/kaleido-io/fabric-sdk-go v1.0.1-0.20221104172459-a5cbbfd0c1d6 h1:pNshpmQHZ48yUgUyYRD8xXo7b0z47Sqoyl6aHUMVYkg=
-github.com/kaleido-io/fabric-sdk-go v1.0.1-0.20221104172459-a5cbbfd0c1d6/go.mod h1:JRplpKBeAvXjsBhOCCM/KvMRUbdDyhsAh80qbXzKc10=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/internal/fabric/client/rpc_test.go
+++ b/internal/fabric/client/rpc_test.go
@@ -234,14 +234,14 @@ func TestGatewayClientSendTx(t *testing.T) {
 	wrapper.gatewayCreator = createMockGateway
 	wrapper.networkCreator = createMockNetwork
 
-	mockPrepareTx := func(w *gwRPCWrapper, signer, channelId, chaincodeName, method string, isInit bool) (*gateway.Transaction, <-chan *fab.TxStatusEvent, error) {
+	mockPrepareTx := func(w *gwRPCWrapper, signer, channelId, chaincodeName, method string, isInit bool, transientMap map[string][]byte) (*gateway.Transaction, <-chan *fab.TxStatusEvent, error) {
 		notifier := make(chan *fab.TxStatusEvent)
 		go func() {
 			notifier <- &fab.TxStatusEvent{}
 		}()
 		return nil, notifier, nil
 	}
-	mockSubmitTx := func(tx *gateway.Transaction, transientMap map[string][]byte, args ...string) ([]byte, error) {
+	mockSubmitTx := func(tx *gateway.Transaction, args ...string) ([]byte, error) {
 		return []byte(""), nil
 	}
 	wrapper.txPreparer = mockPrepareTx
@@ -270,14 +270,14 @@ func TestGatewayClientSendInitTx(t *testing.T) {
 	wrapper.gatewayCreator = createMockGateway
 	wrapper.networkCreator = createMockNetwork
 
-	mockPrepareTx := func(w *gwRPCWrapper, signer, channelId, chaincodeName, method string, isInit bool) (*gateway.Transaction, <-chan *fab.TxStatusEvent, error) {
+	mockPrepareTx := func(w *gwRPCWrapper, signer, channelId, chaincodeName, method string, isInit bool, transientMap map[string][]byte) (*gateway.Transaction, <-chan *fab.TxStatusEvent, error) {
 		notifier := make(chan *fab.TxStatusEvent)
 		go func() {
 			notifier <- &fab.TxStatusEvent{}
 		}()
 		return nil, notifier, nil
 	}
-	mockSubmitTx := func(tx *gateway.Transaction, transientMap map[string][]byte, args ...string) ([]byte, error) {
+	mockSubmitTx := func(tx *gateway.Transaction, args ...string) ([]byte, error) {
 		return []byte(""), nil
 	}
 	wrapper.txPreparer = mockPrepareTx


### PR DESCRIPTION
The proper way to use the transient map support of the fabric go sdk is specifying it with `WithTransient()` when creating the transaction.