### PR TITLE
Update fabconnect to send receipts conforming to FireFly receipt stru…

### DIFF
--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -144,14 +144,15 @@ type LedgerQueryResult struct {
 	Result interface{} `json:"result"`
 }
 
-// TransactionReceipt is sent when a transaction has been successfully mined
+// TransactionReceipt is sent when a transaction has been successfully mined. Must
+// conform to the FireFly standard structure for a blockchain receipt (see BlockchainReceiptNotification{})
 type TransactionReceipt struct {
 	ReplyCommon
-	BlockNumber   uint64 `json:"blockNumber"`
-	SignerMSP     string `json:"signerMSP"`
-	Signer        string `json:"signer"`
-	TransactionID string `json:"transactionID"`
-	Status        string `json:"status"`
+	BlockNumber     uint64 `json:"blockNumber"`
+	SignerMSP       string `json:"signerMSP"`
+	Signer          string `json:"signer"`
+	TransactionHash string `json:"transactionHash"`
+	Status          string `json:"status"`
 }
 
 type ErrorReply struct {

--- a/internal/rest/receipt/receiptstore_test.go
+++ b/internal/rest/receipt/receiptstore_test.go
@@ -48,7 +48,7 @@ func TestReplyProcessorWithValidReply(t *testing.T) {
 	replyMsg.Headers.ID = utils.UUIDv4()
 	replyMsg.Headers.ReqID = utils.UUIDv4()
 	replyMsg.Headers.ReqOffset = "topic:1:2"
-	replyMsg.TransactionID = "9c842ffd430a56a5338f353a7b5b5052b4ac604564d82318af9329b4bf46dd89"
+	replyMsg.TransactionHash = "9c842ffd430a56a5338f353a7b5b5052b4ac604564d82318af9329b4bf46dd89"
 	replyMsgBytes, _ := json.Marshal(&replyMsg)
 
 	r.ProcessReceipt(replyMsgBytes)
@@ -77,7 +77,7 @@ func TestReplyProcessorWithPeristenceErrorPanics(t *testing.T) {
 	replyMsg.Headers.ID = utils.UUIDv4()
 	replyMsg.Headers.ReqID = utils.UUIDv4()
 	replyMsg.Headers.ReqOffset = "topic:1:2"
-	replyMsg.TransactionID = "9c842ffd430a56a5338f353a7b5b5052b4ac604564d82318af9329b4bf46dd89"
+	replyMsg.TransactionHash = "9c842ffd430a56a5338f353a7b5b5052b4ac604564d82318af9329b4bf46dd89"
 	replyMsgBytes, _ := json.Marshal(&replyMsg)
 
 	assert.Panics(t, func() {
@@ -99,7 +99,7 @@ func TestReplyProcessorWithPeristenceErrorDuplicateSwallows(t *testing.T) {
 	replyMsg.Headers.ID = utils.UUIDv4()
 	replyMsg.Headers.ReqID = utils.UUIDv4()
 	replyMsg.Headers.ReqOffset = "topic:1:2"
-	replyMsg.TransactionID = "9c842ffd430a56a5338f353a7b5b5052b4ac604564d82318af9329b4bf46dd89"
+	replyMsg.TransactionHash = "9c842ffd430a56a5338f353a7b5b5052b4ac604564d82318af9329b4bf46dd89"
 	replyMsgBytes, _ := json.Marshal(&replyMsg)
 
 	r.ProcessReceipt(replyMsgBytes)
@@ -181,7 +181,7 @@ func TestSendReplyBroadcast(t *testing.T) {
 	replyMsg.Headers.ID = utils.UUIDv4()
 	replyMsg.Headers.ReqID = utils.UUIDv4()
 	replyMsg.Headers.ReqOffset = "topic:1:2"
-	replyMsg.TransactionID = "9c842ffd430a56a5338f353a7b5b5052b4ac604564d82318af9329b4bf46dd89"
+	replyMsg.TransactionHash = "9c842ffd430a56a5338f353a7b5b5052b4ac604564d82318af9329b4bf46dd89"
 	replyMsgBytes, _ := json.Marshal(&replyMsg)
 
 	r.ProcessReceipt(replyMsgBytes)

--- a/internal/tx/txprocessor.go
+++ b/internal/tx/txprocessor.go
@@ -237,7 +237,7 @@ func (p *txProcessor) waitForCompletion(inflight *inflightTx, initialWaitDelay t
 		reply.BlockNumber = receipt.BlockNumber
 		reply.Signer = receipt.Signer
 		reply.SignerMSP = receipt.SignerMSP
-		reply.TransactionID = receipt.TransactionID
+		reply.TransactionHash = receipt.TransactionID
 
 		inflight.txContext.Reply(&reply)
 	}


### PR DESCRIPTION
…cture

See PR https://github.com/hyperledger/firefly/pull/1111 which standardises the format of a blockchain receipt notification to FireFly core. The standard structure defined in that PR requires transaction hash to be represented as a common field between all blockchain connectors. Before now Fabconnect used `transactionId` and ethconnect used `transactionHash`, and hence each plugin in FireFly core had its own logic for parsing transaction receipts. PR https://github.com/hyperledger/firefly/pull/1111 standardises on `transactionHash` so this PR brings fabconnect into line with that change. This allows FireFly core to have common blockchain receipt processing code.

Signed-off-by: Matthew Whitehead <matthew.whitehead@kaleido.io>