### PR TITLE
Update README.md, payloadType can now only be an empty string, "strin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ An event subscription can be created as follows which contains instructions to d
   "filter": {
     "chaincodeId": "assettransfercomplex"
   },
-  "payloadType": "stringifiedJSON"
+  "payloadType": "string"
 }
 ```
 


### PR DESCRIPTION
Update README.md, payloadType can now only be an empty string, "string" or "json"

Signed-off-by: Kmilo Denis Glez <kmilo.denis.glez@yandex.com>