### PR TITLE
adding high/critical severity vuln checks

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# not relevant to the way grpc is used in fabconnect
+# see https://github.com/hyperledger/firefly-fabconnect/pull/123#discussion_r1543748524
+GHSA-m425-mq94-257g

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,11 @@ RUN make
 
 FROM alpine:3.19 AS SBOM
 WORKDIR /
-ADD . /SBOM
+COPY . /SBOM
 RUN apk add --no-cache curl
 RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.48.3
 RUN trivy fs --format spdx-json --output /sbom.spdx.json /SBOM
-RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --exit-code 1
+RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --exit-code 1 --ignorefile /SBOM/.trivyignore
 
 FROM alpine:3.19
 WORKDIR /fabconnect

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,18 @@ RUN mkdir /.cache \
     && chmod -R g+rwX /.cache
 RUN make
 
+FROM alpine:3.19 AS SBOM
+WORKDIR /
+ADD . /SBOM
+RUN apk add --no-cache curl
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.48.3
+RUN trivy fs --format spdx-json --output /sbom.spdx.json /SBOM
+RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --exit-code 1
+
 FROM alpine:3.19
 WORKDIR /fabconnect
 COPY --from=fabconnect-builder /fabconnect/fabconnect ./
 ADD ./openapi ./openapi/
 RUN ln -s /fabconnect/fabconnect /usr/bin/fabconnect
+COPY --from=SBOM /sbom.spdx.json /sbom.spdx.json
 ENTRYPOINT [ "fabconnect" ]


### PR DESCRIPTION
This Pull request updates the Dockerfile to check dependencies of this source code, and fail to build if high/critical severity vulnerabilities are detected.

Currently this one is detected:

```
8.938 go.mod (gomod)
8.938 ==============
8.938 Total: 1 (UNKNOWN: 0, HIGH: 1, CRITICAL: 0)
8.938 
8.938 ┌────────────────────────┬─────────────────────┬──────────┬────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────┐
8.938 │        Library         │    Vulnerability    │ Severity │ Status │ Installed Version │     Fixed Version      │                       Title                       │
8.938 ├────────────────────────┼─────────────────────┼──────────┼────────┼───────────────────┼────────────────────────┼───────────────────────────────────────────────────┤
8.938 │ google.golang.org/grpc │ GHSA-m425-mq94-257g │ HIGH     │ fixed  │ 1.29.0            │ 1.56.3, 1.57.1, 1.58.3 │ gRPC-Go HTTP/2 Rapid Reset vulnerability          │
8.938 │                        │                     │          │        │                   │                        │ https://github.com/advisories/GHSA-m425-mq94-257g │
8.938 └────────────────────────┴─────────────────────┴──────────┴────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────┘
------
```

This is done with the help of Trivy, an open source scanning tool from Aquasec. Trivy is RedHat certified, and is being used as the default container scanner on GitLab (according [to this link](https://www.aquasec.com/products/trivy/))