### PR TITLE
chore: relax go directive to 1.26.0, keep toolchain at 1.26.4

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -28,7 +28,7 @@ jobs:
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
             --build-arg BASE_IMAGE=alpine:3.19 \
-            --build-arg BUILD_IMAGE=golang:1.26.4-alpine3.24 \
+            --build-arg BUILD_IMAGE=golang:1.26-alpine3.24 \
             --tag ghcr.io/hyperledger-firefly/fabconnect:${{ steps.build_tag_generator.outputs.BUILD_TAG }} .
 
       - name: Tag release

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -20,7 +20,7 @@ jobs:
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${GITHUB_REF##*/} \
             --build-arg BASE_IMAGE=alpine:3.19 \
-            --build-arg BUILD_IMAGE=golang:1.26.4-alpine3.24 \
+            --build-arg BUILD_IMAGE=golang:1.26-alpine3.24 \
             --tag ghcr.io/hyperledger-firefly/fabconnect:${GITHUB_REF##*/} \
             --tag ghcr.io/hyperledger-firefly/fabconnect:head \
             .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26"
           check-latest: true
 
       - name: Build and Test
@@ -43,5 +43,5 @@ jobs:
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
             --build-arg BASE_IMAGE=alpine:3.19 \
-            --build-arg BUILD_IMAGE=golang:1.26.4-alpine3.24 \
+            --build-arg BUILD_IMAGE=golang:1.26-alpine3.24 \
             --tag ghcr.io/hyperledger-firefly/fabconnect:${{ steps.build_tag_generator.outputs.BUILD_TAG }} .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/hyperledger-firefly/fabconnect
 
-go 1.26.4
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/Shopify/sarama v1.38.1


### PR DESCRIPTION
Set the go directive to 1.26.0 with toolchain go1.26.4, and pin workflows and Docker build images to the 1.26 minor.